### PR TITLE
Add option to ignore network errors

### DIFF
--- a/.snapshots/TestHelp
+++ b/.snapshots/TestHelp
@@ -2,45 +2,53 @@ Usage:
   muffet.test [options] <url>
 
 Application Options:
-      --accepted-status-codes=<codes>       Accepted HTTP response status codes
-                                            (e.g. '200..300,403') (default:
-                                            200..300)
-  -b, --buffer-size=<size>                  HTTP response buffer size in bytes
-                                            (default: 4096)
-  -c, --max-connections=<count>             Maximum number of HTTP connections
-                                            (default: 512)
-      --max-connections-per-host=<count>    Maximum number of HTTP connections
-                                            per host (default: 512)
-      --max-response-body-size=<size>       Maximum response body size to read
-                                            (default: 10000000)
-  -e, --exclude=<pattern>...                Exclude URLs matched with given
-                                            regular expressions
-  -i, --include=<pattern>...                Include URLs matched with given
-                                            regular expressions
-      --follow-robots-txt                   Follow robots.txt when scraping
-                                            pages
-      --follow-sitemap-xml                  Scrape only pages listed in
-                                            sitemap.xml (deprecated)
-      --header=<header>...                  Custom headers
-  -f, --ignore-fragments                    Ignore URL fragments
-      --dns-resolver=<address>              Custom DNS resolver
-      --format=[text|json|junit]            Output format (default: text)
-      --json                                Output results in JSON (deprecated)
-      --experimental-verbose-json           Include successful results in JSON
-                                            (deprecated)
-      --junit                               Output results as JUnit XML file
-                                            (deprecated)
-  -r, --max-redirections=<count>            Maximum number of redirections
-                                            (default: 64)
-      --rate-limit=<rate>                   Max requests per second
-  -t, --timeout=<seconds>                   Timeout for HTTP requests in
-                                            seconds (default: 10)
-  -v, --verbose                             Show successful results too
-      --proxy=<host>                        HTTP proxy host
-      --skip-tls-verification               Skip TLS certificate verification
-      --one-page-only                       Only check links found in the given
-                                            URL
-      --color=[auto|always|never]           Color output (default: auto)
-  -h, --help                                Show this help
-      --version                             Show version
+      --accepted-status-codes=<codes>                Accepted HTTP response
+                                                     status codes (e.g.
+                                                     '200..300,403') (default:
+                                                     200..300)
+  -b, --buffer-size=<size>                           HTTP response buffer size
+                                                     in bytes (default: 4096)
+  -c, --max-connections=<count>                      Maximum number of HTTP
+                                                     connections (default: 512)
+      --max-connections-per-host=<count>             Maximum number of HTTP
+                                                     connections per host
+                                                     (default: 512)
+      --max-response-body-size=<size>                Maximum response body size
+                                                     to read (default: 10000000)
+  -e, --exclude=<pattern>...                         Exclude URLs matched with
+                                                     given regular expressions
+  -i, --include=<pattern>...                         Include URLs matched with
+                                                     given regular expressions
+      --follow-robots-txt                            Follow robots.txt when
+                                                     scraping pages
+      --follow-sitemap-xml                           Scrape only pages listed
+                                                     in sitemap.xml (deprecated)
+      --header=<header>...                           Custom headers
+  -f, --ignore-fragments                             Ignore URL fragments
+      --ignore-network-errors=[none|all|external]    Ignore network errors and
+                                                     timeouts (default: none)
+      --dns-resolver=<address>                       Custom DNS resolver
+      --format=[text|json|junit]                     Output format (default:
+                                                     text)
+      --json                                         Output results in JSON
+                                                     (deprecated)
+      --experimental-verbose-json                    Include successful results
+                                                     in JSON (deprecated)
+      --junit                                        Output results as JUnit
+                                                     XML file (deprecated)
+  -r, --max-redirections=<count>                     Maximum number of
+                                                     redirections (default: 64)
+      --rate-limit=<rate>                            Max requests per second
+  -t, --timeout=<seconds>                            Timeout for HTTP requests
+                                                     in seconds (default: 10)
+  -v, --verbose                                      Show successful results too
+      --proxy=<host>                                 HTTP proxy host
+      --skip-tls-verification                        Skip TLS certificate
+                                                     verification
+      --one-page-only                                Only check links found in
+                                                     the given URL
+      --color=[auto|always|never]                    Color output (default:
+                                                     auto)
+  -h, --help                                         Show this help
+      --version                                      Show version
 

--- a/arguments.go
+++ b/arguments.go
@@ -22,9 +22,10 @@ type arguments struct {
 	FollowSitemapXML       bool     `long:"follow-sitemap-xml" description:"Scrape only pages listed in sitemap.xml (deprecated)"`
 	RawHeaders             []string `long:"header" value-name:"<header>..." description:"Custom headers"`
 	// TODO Remove a short option.
-	IgnoreFragments bool   `short:"f" long:"ignore-fragments" description:"Ignore URL fragments"`
-	DnsResolver     string `long:"dns-resolver" value-name:"<address>" description:"Custom DNS resolver"`
-	Format          string `long:"format" description:"Output format" default:"text" choice:"text" choice:"json" choice:"junit"`
+	IgnoreFragments     bool                `short:"f" long:"ignore-fragments" description:"Ignore URL fragments"`
+	IgnoreNetworkErrors ignoreNetworkErrors `long:"ignore-network-errors" description:"Ignore network errors and timeouts" choice:"none" choice:"all" choice:"external" default:"none"`
+	DnsResolver         string              `long:"dns-resolver" value-name:"<address>" description:"Custom DNS resolver"`
+	Format              string              `long:"format" description:"Output format" default:"text" choice:"text" choice:"json" choice:"junit"`
 	// TODO Remove this option.
 	JSONOutput bool `long:"json" description:"Output results in JSON (deprecated)"`
 	// TODO Remove this option.

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -35,6 +35,8 @@ func TestGetArguments(t *testing.T) {
 		{"--verbose", "https://foo.com"},
 		{"-v", "-f", "https://foo.com"},
 		{"-v", "--ignore-fragments", "https://foo.com"},
+		{"--ignore-network-errors", "all", "https://foo.com"},
+		{"--ignore-network-errors", "external", "https://foo.com"},
 		{"--one-page-only", "https://foo.com"},
 		{"--json", "https://foo.com"},
 		{"-h"},
@@ -61,6 +63,7 @@ func TestGetArgumentsError(t *testing.T) {
 		{"--max-redirections", "foo", "https://foo.com"},
 		{"-t", "foo", "https://foo.com"},
 		{"--timeout", "foo", "https://foo.com"},
+		{"--ignore-network-errors", "foo", "https://foo.com"},
 	} {
 		_, err := getArguments(ss)
 		assert.NotNil(t, err)

--- a/command.go
+++ b/command.go
@@ -112,6 +112,7 @@ func (c *command) runWithError(ss []string) (bool, error) {
 		f,
 		newLinkValidator(p.URL().Hostname(), rd, sm),
 		args.OnePageOnly,
+		args.IgnoreNetworkErrors,
 	)
 
 	go checker.Check(p)

--- a/ignore_network_errors.go
+++ b/ignore_network_errors.go
@@ -1,0 +1,9 @@
+package main
+
+type ignoreNetworkErrors string
+
+const (
+	ignoreNetworkErrorsNone     ignoreNetworkErrors = "none"
+	ignoreNetworkErrorsAll      ignoreNetworkErrors = "all"
+	ignoreNetworkErrorsExternal ignoreNetworkErrors = "external"
+)


### PR DESCRIPTION
## Summary
- add `ignoreNetworkErrors` setting and CLI option `--ignore-network-errors`
- skip network error results in `pageChecker` when configured
- update command and tests accordingly

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_685c6adfed9c8324ad7029c1381b47d2